### PR TITLE
Allow to change the price entity id retrospecitvely

### DIFF
--- a/custom_components/epex_spot_sensor/config_flow.py
+++ b/custom_components/epex_spot_sensor/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for EPEX Spot Sensor component."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -30,6 +31,9 @@ from .const import (
 
 OPTIONS_SCHEMA = vol.Schema(
     {
+        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN)
+        ),
         vol.Required(CONF_EARLIEST_START_TIME): selector.TimeSelector(),
         vol.Required(CONF_LATEST_END_TIME): selector.TimeSelector(),
         vol.Required(CONF_DURATION, default={"hours": 1}): selector.DurationSelector(),
@@ -67,9 +71,6 @@ OPTIONS_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): selector.TextSelector(),
-        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN)
-        ),
     }
 ).extend(OPTIONS_SCHEMA.schema)
 

--- a/custom_components/epex_spot_sensor/translations/en.json
+++ b/custom_components/epex_spot_sensor/translations/en.json
@@ -28,6 +28,7 @@
     "step": {
       "init": {
         "data": {
+          "entity_id": "Price Input Sensor",
           "earliest_start_time": "Earliest Start Time",
           "latest_end_time": "Latest End Time",
           "duration": "Duration",


### PR DESCRIPTION
This PR enables changing the price entity id after setup. This is necessary because the main integration changes the net_price sensor name and thus new sensors need to be setup.