### PR TITLE
use constants in place of hardcoded  start_time and end_time, and stop recomputing price

### DIFF
--- a/custom_components/epex_spot_sensor/intermittent_interval.py
+++ b/custom_components/epex_spot_sensor/intermittent_interval.py
@@ -78,8 +78,8 @@ def calc_intervals_for_intermittent(
 
         price = (
             mp.price
-            * active_duration_in_this_segment.total_seconds()
-            / SECONDS_PER_HOUR
+#            * active_duration_in_this_segment.total_seconds()
+#            / SECONDS_PER_HOUR
         )
 
         intervals.append(

--- a/custom_components/epex_spot_sensor/util.py
+++ b/custom_components/epex_spot_sensor/util.py
@@ -4,13 +4,32 @@ from homeassistant.helpers import (
     config_validation as cv,
 )
 
+from .const import (
+    ATTR_DATA,
+    ATTR_END_TIME,
+    ATTR_INTERVAL_ENABLED,
+    ATTR_MEAN_PRICE_PER_KWH,
+    ATTR_PRICE_PER_KWH,
+    ATTR_RANK,
+    ATTR_START_TIME,
+    CONF_DURATION,
+    CONF_DURATION_ENTITY_ID,
+    CONF_EARLIEST_START_TIME,
+    CONF_INTERVAL_MODE,
+    CONF_INTERVAL_START_TIME,
+    CONF_LATEST_END_TIME,
+    CONF_PRICE_MODE,
+    IntervalModes,
+    PriceModes,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class Marketprice:
     def __init__(self, entry):
-        self._start_time = cv.datetime(entry["start_time"])
-        self._end_time = cv.datetime(entry["end_time"])
+        self._start_time = cv.datetime(entry[ATTR_START_TIME])
+        self._end_time = cv.datetime(entry[ATTR_END_TIME])
         if (x := entry.get("price_eur_per_mwh")) is not None:
             self._price = x
             self._price_uom = "EUR/MWh"


### PR DESCRIPTION
1) Remove hardcoded "start_time" and "end_time" and reuse definitions in ".const" file
2) Don't recompute price 