### PR TITLE
Add epex_spot dependency

### DIFF
--- a/custom_components/epex_spot_sensor/manifest.json
+++ b/custom_components/epex_spot_sensor/manifest.json
@@ -1,7 +1,12 @@
 {
   "domain": "epex_spot_sensor",
   "name": "EPEX Spot Sensor",
-  "codeowners": ["@mampfes"],
+  "codeowners": [
+    "@mampfes"
+  ],
+  "after_dependencies": [
+    "epex_spot"
+  ],
   "config_flow": true,
   "documentation": "https://github.com/mampfes/ha_epex_spot_sensor",
   "integration_type": "helper",


### PR DESCRIPTION
Epex spot sensor should only start after epex spot. This PR adds this dependency. 