### PR TITLE
Fix Remaining Duration Entity faults

### DIFF
--- a/custom_components/epex_spot_sensor/binary_sensor.py
+++ b/custom_components/epex_spot_sensor/binary_sensor.py
@@ -212,6 +212,22 @@ class BinarySensor(BinarySensorEntity):
 
     @callback
     def _update_state(self) -> None:
+        # Always write the state at the end, even if the calculation raises or
+        # returns early. Otherwise an exception (or early return) would leave the
+        # last written state in place, so the sensor would appear "stuck" on its
+        # previous value instead of becoming unavailable/off.
+        try:
+            self._calc_state()
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception(
+                f"Failed to update state of EPEX Spot binary sensor {self._attr_name}"
+            )
+            self._sensor_attributes = None
+            self._state = None
+
+        self.async_write_ha_state()
+
+    def _calc_state(self) -> None:
         # set to unavailable by default
         self._sensor_attributes = None
         self._state = None
@@ -255,6 +271,20 @@ class BinarySensor(BinarySensorEntity):
         # calculate the actual duration (in case a duration entity is configured)
         self._calculate_duration()
 
+        # clamp the duration to the available window: if the requested duration is
+        # longer than the window (latest_end - earliest_start), run for the whole
+        # window instead of turning the sensor off.
+        window = latest_end - self._interval_start_time
+        if self._duration > window:
+            self._duration = window
+
+        # a non-positive duration means there is nothing to schedule, so the sensor
+        # is off (and we avoid a division-by-zero in the interval calculation).
+        if self._duration <= timedelta(0):
+            self._state = False
+            self._intervals = []
+            return
+
         if self._interval_mode == IntervalModes.INTERMITTENT.value:
             self._update_state_for_intermittent(
                 self._interval_start_time, latest_end, now
@@ -265,8 +295,6 @@ class BinarySensor(BinarySensorEntity):
             )
         else:
             _LOGGER.error(f"invalid interval mode: {self._interval_mode}")
-
-        self.async_write_ha_state()
 
     def _update_state_for_intermittent(
         self, earliest_start: time, latest_end: time, now: datetime

--- a/custom_components/epex_spot_sensor/contiguous_interval.py
+++ b/custom_components/epex_spot_sensor/contiguous_interval.py
@@ -105,11 +105,17 @@ def _find_extreme_price_interval(
     if interval_start_time is None:
         return None
 
+    duration_seconds = duration.total_seconds()
+
     return {
         "start": interval_start_time,
         "end": interval_start_time + duration,
         "interval_price": interval_price,
-        "price_per_hour": interval_price * SECONDS_PER_HOUR / duration.total_seconds(),
+        "price_per_hour": (
+            interval_price * SECONDS_PER_HOUR / duration_seconds
+            if duration_seconds > 0
+            else 0
+        ),
     }
 
 


### PR DESCRIPTION
I got sick of babysitting my washer-dryer automation because issue #58 kept breaking it. I'm not a programmer, but know just enough to be able to leverage Claude Code. I had it fix the issue and deployed the fix on my Prod HA. It's been running flawlessly for a couple of weeks now.

Claude's drafting follows

___

In contiguous interval mode, a duration of `0` — which happens routinely when the Remaining Duration Entity points at an appliance "time remaining" sensor that reads `0` while idle — crashed the sensor and left it stuck or unknown. This addresses all four symptoms reported in the issue.

### Root cause:
Two compounding bugs:

1. `ZeroDivisionError` on zero `duration.contiguous_interval.py` computes `price_per_hour = interval_price * SECONDS_PER_HOUR / duration.total_seconds()`, which divides by zero when the duration is `0`.
2. State only written on the success path. `_update_state()` resets the state to `None` at the top but only calls `async_write_ha_state()` at the end. Any exception (like #1) or early return therefore leaves the previous state in HA, so the entity freezes on its last value instead of updating.

Together these explain the reported behaviour: a duration of `0` on first setup → entity never gets a state → permanently unknown; a duration that later drops to `0` → entity frozen on its last value instead of turning off.

A third, related gap: when the requested duration is longer than the available window (`latest_end − earliest_start`), contiguous mode produced no candidate start times → returned `None` → sensor `off`, rather than running for the whole window.

### Changes

- `binary_sensor.py` — wrap the state calculation so `async_write_ha_state()` always runs (errors now correctly mark the sensor unavailable instead of freezing it); treat a non-positive duration as "nothing to schedule" → `off`; clamp an over-window duration to the available window so the sensor stays `on` for the whole window.

- `contiguous_interval.py` — guard the `price_per_hour` division against a zero duration.
(Intermittent mode was already safe for zero duration; no behaviour change there. Version bump/release intentionally left out for the maintainer.)

### Verification

- Unit-level: zero duration no longer raises and yields an empty interval; normal durations still pick the correct cheapest window; an over-window duration now covers the full window.

- Live: deployed to a production HA instance with 3 contiguous sensors bound to appliance "remaining time" entities. Confirmed the recurring `ZeroDivisionError: division by zero` traces stopped, and an isolated contiguous sensor configured with duration `0` now comes up `off` (previously failed to initialise → `unknown`). Ran clean for an extended period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)